### PR TITLE
Corrigi duplicação de menu na MapasActivity

### DIFF
--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_1_7" project-jdk-name="1.8 (2)" project-jdk-type="JavaSDK">
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_1_7" project-jdk-name="1.8" project-jdk-type="JavaSDK">
     <output url="file://$PROJECT_DIR$/build/classes" />
   </component>
   <component name="ProjectType">

--- a/app/src/main/java/br/edu/uniredentor/tachegando/MapasActivity.java
+++ b/app/src/main/java/br/edu/uniredentor/tachegando/MapasActivity.java
@@ -78,16 +78,21 @@ public class MapasActivity extends FragmentActivity implements OnMapReadyCallbac
 
         mapFragment = (SupportMapFragment) getSupportFragmentManager()
                 .findFragmentById(R.id.map);
+
+        criaToolbar();
         criaDemo();
         iniciaMapa();
     }
 
     private void iniciaMapa() {
-        Toolbar toolbarPrincipal = findViewById(R.id.toolbar_principal);
-        toolbarPrincipal.setTitle(getString(R.string.app_name));
         mostraMapa();
         buscarViagens();
+        mapeiaViagens();
+    }
 
+    private void criaToolbar() {
+        Toolbar toolbarPrincipal = findViewById(R.id.toolbar_principal);
+        toolbarPrincipal.setTitle(getString(R.string.app_name));
         toolbarPrincipal.inflateMenu(R.menu.menu_principal);
         toolbarPrincipal.setOnMenuItemClickListener(new Toolbar.OnMenuItemClickListener() {
             @Override
@@ -110,7 +115,6 @@ public class MapasActivity extends FragmentActivity implements OnMapReadyCallbac
                 return false;
             }
         });
-        mapeiaViagens();
     }
 
     private void mostraMapa() {


### PR DESCRIPTION
Corrigi uma duplicação do menu que ocorria na Toolbar da MapasActivity quando se abria o aplicativo pela primeira vez e aceitava o acesso a localização.